### PR TITLE
feat(reading-tracker): add custom total page count support

### DIFF
--- a/lib/core/services/sqflite_service.dart
+++ b/lib/core/services/sqflite_service.dart
@@ -23,7 +23,7 @@ class SqfliteService {
       final fullPath = join(dbPath, dbName);
       return await openDatabase(
         fullPath,
-        version: 2,
+        version: 3,
         onCreate: _onCreate,
         onUpgrade: _onUpgrade,
         onConfigure: (db) async {
@@ -39,7 +39,7 @@ class SqfliteService {
       return await databaseFactory.openDatabase(
         fullPath,
         options: OpenDatabaseOptions(
-          version: 2,
+          version: 3,
           onCreate: _onCreate,
           onUpgrade: _onUpgrade,
           onConfigure: (db) async {
@@ -71,7 +71,8 @@ class SqfliteService {
         bookId TEXT PRIMARY KEY,
         currentPage INTEGER,
         totalReadingTimeInSeconds INTEGER,
-        lastRead TEXT
+        lastRead TEXT,
+        userPageCount INTEGER
       )
     ''');
     await db.execute('''
@@ -158,6 +159,16 @@ class SqfliteService {
           FOREIGN KEY (book_id) REFERENCES bookmarks(id) ON DELETE CASCADE
         )
       ''');
+    }
+
+    if (oldVersion < 3) {
+      try {
+        await db.execute(
+          'ALTER TABLE reading_progress ADD COLUMN userPageCount INTEGER',
+        );
+      } catch (e) {
+        log('Migration v3: column may already exist — $e');
+      }
     }
   }
 
@@ -253,6 +264,20 @@ class SqfliteService {
     } catch (e, stack) {
       log('getAllReadingSessions error: $e\n$stack');
       return [];
+    }
+  }
+
+  Future<void> updateUserPageCount(String bookId, int userPageCount) async {
+    try {
+      final db = await database;
+      await db.update(
+        'reading_progress',
+        {'userPageCount': userPageCount},
+        where: 'bookId = ?',
+        whereArgs: [bookId],
+      );
+    } catch (e, stack) {
+      log('updateUserPageCount error: $e\n$stack');
     }
   }
 

--- a/lib/features/reading_tracker/model/reading_progress_model.dart
+++ b/lib/features/reading_tracker/model/reading_progress_model.dart
@@ -6,6 +6,7 @@ class ReadingProgressModel {
   final int totalReadingTimeInSeconds;
   final DateTime? lastRead;
   final Book? book;
+  final int? userPageCount;
 
   const ReadingProgressModel({
     required this.bookId,
@@ -13,7 +14,10 @@ class ReadingProgressModel {
     this.totalReadingTimeInSeconds = 0,
     this.lastRead,
     this.book,
+    this.userPageCount,
   });
+
+  int get effectivePageCount => userPageCount ?? book?.pageCount ?? 0;
 
   ReadingProgressModel copyWith({
     String? bookId,
@@ -21,6 +25,7 @@ class ReadingProgressModel {
     int? totalReadingTimeInSeconds,
     DateTime? lastRead,
     Book? book,
+    int? userPageCount,
   }) {
     return ReadingProgressModel(
       bookId: bookId ?? this.bookId,
@@ -29,6 +34,7 @@ class ReadingProgressModel {
           totalReadingTimeInSeconds ?? this.totalReadingTimeInSeconds,
       lastRead: lastRead ?? this.lastRead,
       book: book ?? this.book,
+      userPageCount: userPageCount ?? this.userPageCount,
     );
   }
 
@@ -41,6 +47,7 @@ class ReadingProgressModel {
       lastRead: json['lastRead'] != null
           ? DateTime.tryParse(json['lastRead'] as String)
           : null,
+      userPageCount: json['userPageCount'] as int?,
     );
   }
 
@@ -50,6 +57,7 @@ class ReadingProgressModel {
       'currentPage': currentPage,
       'totalReadingTimeInSeconds': totalReadingTimeInSeconds,
       'lastRead': lastRead?.toIso8601String(),
+      if (userPageCount != null) 'userPageCount': userPageCount,
     };
   }
 
@@ -61,7 +69,8 @@ class ReadingProgressModel {
         other.currentPage == currentPage &&
         other.totalReadingTimeInSeconds == totalReadingTimeInSeconds &&
         other.lastRead == lastRead &&
-        other.book == book;
+        other.book == book &&
+        other.userPageCount == userPageCount;
   }
 
   @override
@@ -72,11 +81,12 @@ class ReadingProgressModel {
       totalReadingTimeInSeconds,
       lastRead,
       book,
+      userPageCount,
     );
   }
 
   @override
   String toString() {
-    return 'ReadingProgressModel(bookId: $bookId, currentPage: $currentPage, totalReadingTimeInSeconds: $totalReadingTimeInSeconds, lastRead: $lastRead, book: $book)';
+    return 'ReadingProgressModel(bookId: $bookId, currentPage: $currentPage, totalReadingTimeInSeconds: $totalReadingTimeInSeconds, lastRead: $lastRead, book: $book, userPageCount: $userPageCount)';
   }
 }

--- a/lib/features/reading_tracker/view/reading_tracker_detail_page.dart
+++ b/lib/features/reading_tracker/view/reading_tracker_detail_page.dart
@@ -34,11 +34,12 @@ class ReadingTrackerDetailPage extends ConsumerWidget {
           }
           final book = progress.book!;
           final scheme = Theme.of(context).colorScheme;
-          final double progressValue = book.pageCount > 0
-              ? progress.currentPage / book.pageCount
+          final effectiveTotal = progress.effectivePageCount;
+          final double progressValue = effectiveTotal > 0
+              ? progress.currentPage / effectiveTotal
               : 0.0;
           final String progressText =
-              '${progress.currentPage} / ${book.pageCount} pages';
+              '${progress.currentPage} / $effectiveTotal pages';
 
           return SafeArea(
             child: SingleChildScrollView(
@@ -101,7 +102,9 @@ class ReadingTrackerDetailPage extends ConsumerWidget {
                                     style: context.textTheme.bodyMedium,
                                   ),
                                   Text(
-                                    'Total Pages: ${book.pageCount}',
+                                    progress.userPageCount != null
+                                        ? 'Total Pages: ${progress.userPageCount} (adjusted from ${book.pageCount})'
+                                        : 'Total Pages: ${book.pageCount}',
                                     style: context.textTheme.bodyMedium,
                                   ),
                                 ],

--- a/lib/features/reading_tracker/view/session_recording_page.dart
+++ b/lib/features/reading_tracker/view/session_recording_page.dart
@@ -7,6 +7,7 @@ import 'package:book_verse/features/reading_tracker/model/reading_progress_model
 import 'package:book_verse/features/reading_tracker/viewmodel/session_recording_viewmodel.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:stop_watch_timer/stop_watch_timer.dart';
 
 class SessionRecordingPage extends ConsumerStatefulWidget {
@@ -20,7 +21,6 @@ class SessionRecordingPage extends ConsumerStatefulWidget {
 
 class _SessionRecordingPageState extends ConsumerState<SessionRecordingPage> {
   final TextEditingController _pageController = TextEditingController();
-  final _formKey = GlobalKey<FormState>();
 
   @override
   void initState() {
@@ -60,98 +60,304 @@ class _SessionRecordingPageState extends ConsumerState<SessionRecordingPage> {
     return "${twoDigits(duration.inHours)}:$twoDigitMinutes:$twoDigitSeconds";
   }
 
-  Future<void> _showSaveSessionDialog(
+  Future<void> _showSaveBottomSheet(
     BuildContext context,
     int previousCurrentPage,
     int totalPages,
   ) async {
-    return showDialog<void>(
+    int adjustedTotal = totalPages;
+    bool isExpanded = false;
+    bool pagesAdjusted = false;
+    final totalPagesController = TextEditingController(
+      text: totalPages.toString(),
+    );
+    final sheetFormKey = GlobalKey<FormState>();
+
+    await showModalBottomSheet<void>(
       context: context,
-      barrierDismissible: false,
-      builder: (BuildContext dialogContext) {
-        return AlertDialog(
-          title: const Text('Finish Reading Session'),
-          content: SingleChildScrollView(
-            child: Form(
-              key: _formKey,
-              child: ListBody(
-                children: <Widget>[
-                  Text(
-                    'Your previous progress: $previousCurrentPage / $totalPages pages',
-                  ),
-                  const SizedBox(height: 16),
-                  TextFormField(
-                    controller: _pageController,
-                    keyboardType: TextInputType.number,
-                    decoration: const InputDecoration(
-                      labelText: 'Last page read in this session',
-                      border: OutlineInputBorder(),
-                    ),
-                    validator: (value) {
-                      if (value == null || value.isEmpty) {
-                        return 'Please enter a page number';
-                      }
-                      final page = int.tryParse(value);
-                      if (page == null) {
-                        return 'Please enter a valid number';
-                      }
-                      if (page < 1 || page > totalPages) {
-                        return 'Page must be between 1 and $totalPages';
-                      }
-                      if (page < previousCurrentPage) {
-                        return 'Page cannot be less than previous progress ($previousCurrentPage)';
-                      }
-                      return null;
-                    },
-                  ),
-                ],
+      isScrollControlled: true,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      builder: (sheetContext) {
+        return StatefulBuilder(
+          builder: (sheetInnerContext, setSheetState) {
+            final effectiveTotal = pagesAdjusted ? adjustedTotal : totalPages;
+
+            String? pageValidator(String? value) {
+              if (value == null || value.isEmpty) {
+                return 'Please enter a page number';
+              }
+              final page = int.tryParse(value);
+              if (page == null) return 'Please enter a valid number';
+              if (page < 1 || page > effectiveTotal) {
+                return 'Page must be between 1 and $effectiveTotal';
+              }
+              if (page < previousCurrentPage) {
+                return 'Page cannot be less than previous progress ($previousCurrentPage)';
+              }
+              return null;
+            }
+
+            final pageText = _pageController.text;
+            final pageVal = int.tryParse(pageText);
+            final showEditionError = pageVal != null && pageVal > totalPages;
+
+            return Padding(
+              padding: EdgeInsets.only(
+                left: 24,
+                right: 24,
+                top: 12,
+                bottom: MediaQuery.of(context).viewInsets.bottom + 24,
               ),
-            ),
-          ),
-          actions: <Widget>[
-            TextButton(
-              child: const Text('Cancel'),
-              onPressed: () {
-                Navigator.of(dialogContext).pop();
-              },
-            ),
-            FilledButton(
-              child: const Text('Save Session'),
-              onPressed: () async {
-                if (_formKey.currentState!.validate()) {
-                  final lastPage = int.parse(_pageController.text);
-                  final navigator = Navigator.of(dialogContext);
-                  final rootNavigator = Navigator.of(context);
-                  final scaffoldMessenger = ScaffoldMessenger.of(context);
-
-                  final sessionNotifier = ref.read(
-                    sessionRecordingNotifierProvider.notifier,
-                  );
-                  final success = await sessionNotifier.saveSession(lastPage);
-
-                  if (success) {
-                    ref.invalidate(bookmarkNotifierProvider);
-                    ref.invalidate(libraryNotifierProvider);
-                    navigator.pop();
-                    rootNavigator.pop();
-                  } else {
-                    scaffoldMessenger.showSnackBar(
-                      SnackBar(
-                        content: Text(
-                          sessionNotifier.errorMessage ??
-                              'Failed to save session',
+              child: Form(
+                key: sheetFormKey,
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Center(
+                      child: Container(
+                        width: 40,
+                        height: 4,
+                        decoration: BoxDecoration(
+                          color: Colors.grey[300],
+                          borderRadius: BorderRadius.circular(2),
                         ),
-                        backgroundColor: Theme.of(context).colorScheme.error,
                       ),
-                    );
-                  }
-                }
-              },
-            ),
-          ],
+                    ),
+                    const SizedBox(height: 20),
+                    Text(
+                      'Finish Reading Session',
+                      style: context.textTheme.titleLarge,
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      'Your progress: $previousCurrentPage / $effectiveTotal pages',
+                      style: context.textTheme.bodyMedium,
+                    ),
+                    const SizedBox(height: 20),
+                    TextFormField(
+                      controller: _pageController,
+                      keyboardType: TextInputType.number,
+                      decoration: const InputDecoration(
+                        labelText: 'Last page read in this session',
+                        border: OutlineInputBorder(),
+                      ),
+                      validator: pageValidator,
+                    ),
+                    if (showEditionError) ...[
+                      const SizedBox(height: 8),
+                      Text(
+                        'Page exceeds edition length',
+                        style: TextStyle(
+                          color: Theme.of(context).colorScheme.error,
+                          fontSize: 13,
+                        ),
+                      ),
+                    ],
+                    const SizedBox(height: 4),
+                    Align(
+                      alignment: Alignment.centerLeft,
+                      child: TextButton.icon(
+                        onPressed: () => setSheetState(() {
+                          if (!isExpanded) {
+                            totalPagesController.text = adjustedTotal
+                                .toString();
+                          }
+                          isExpanded = !isExpanded;
+                        }),
+                        icon: AnimatedRotation(
+                          turns: isExpanded ? 0.5 : 0,
+                          duration: const Duration(milliseconds: 200),
+                          child: const Icon(Icons.expand_more, size: 20),
+                        ),
+                        label: Text(
+                          isExpanded
+                              ? 'Hide edition settings'
+                              : 'Adjust page count',
+                        ),
+                      ),
+                    ),
+                    if (pagesAdjusted) ...[
+                      const SizedBox(height: 6),
+                      Row(
+                        children: [
+                          Icon(
+                            Icons.check_circle,
+                            size: 16,
+                            color: Colors.green[600],
+                          ),
+                          const SizedBox(width: 6),
+                          Text(
+                            'Edition adjusted to $adjustedTotal pages',
+                            style: TextStyle(
+                              color: Colors.green[600],
+                              fontSize: 13,
+                            ),
+                          ),
+                          const Spacer(),
+                          GestureDetector(
+                            onTap: () => setSheetState(() {
+                              pagesAdjusted = false;
+                              adjustedTotal = totalPages;
+                              totalPagesController.text = totalPages.toString();
+                            }),
+                            child: Text(
+                              'Revert',
+                              style: TextStyle(
+                                color: context.textTheme.bodySmall?.color,
+                                fontSize: 13,
+                                decoration: TextDecoration.underline,
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ],
+                    AnimatedSize(
+                      duration: const Duration(milliseconds: 200),
+                      curve: Curves.easeInOut,
+                      alignment: Alignment.topCenter,
+                      child: isExpanded
+                          ? Padding(
+                              padding: const EdgeInsets.only(top: 4),
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  const Divider(),
+                                  const SizedBox(height: 8),
+                                  Text(
+                                    'Edition Settings',
+                                    style: context.textTheme.titleSmall,
+                                  ),
+                                  const SizedBox(height: 4),
+                                  Text(
+                                    'Adjust for your copy',
+                                    style: TextStyle(
+                                      color: context.textTheme.bodySmall?.color,
+                                      fontSize: 13,
+                                    ),
+                                  ),
+                                  const SizedBox(height: 12),
+                                  TextFormField(
+                                    controller: totalPagesController,
+                                    keyboardType: TextInputType.number,
+                                    decoration: InputDecoration(
+                                      labelText: 'Total pages',
+                                      border: const OutlineInputBorder(),
+                                      suffixText: 'pages',
+                                      suffixStyle: TextStyle(
+                                        color:
+                                            context.textTheme.bodySmall?.color,
+                                      ),
+                                    ),
+                                    validator: (value) {
+                                      if (value == null || value.isEmpty) {
+                                        return 'Enter total pages';
+                                      }
+                                      final p = int.tryParse(value);
+                                      if (p == null || p < 1) {
+                                        return 'Enter a valid number';
+                                      }
+                                      return null;
+                                    },
+                                  ),
+                                  const SizedBox(height: 4),
+                                  Text(
+                                    'Reference: $totalPages (Google Books)',
+                                    style: TextStyle(
+                                      color: context.textTheme.bodySmall?.color,
+                                      fontSize: 12,
+                                    ),
+                                  ),
+                                  const SizedBox(height: 12),
+                                  SizedBox(
+                                    width: double.infinity,
+                                    child: FilledButton.tonal(
+                                      onPressed: () {
+                                        if (totalPagesController
+                                            .text
+                                            .isNotEmpty) {
+                                          final newTotal = int.tryParse(
+                                            totalPagesController.text,
+                                          );
+                                          if (newTotal != null &&
+                                              newTotal > 0) {
+                                            setSheetState(() {
+                                              adjustedTotal = newTotal;
+                                              pagesAdjusted = true;
+                                              isExpanded = false;
+                                            });
+                                          }
+                                        }
+                                      },
+                                      child: const Text('Save Changes'),
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            )
+                          : const SizedBox.shrink(),
+                    ),
+                    const SizedBox(height: 20),
+                    Row(
+                      children: [
+                        TextButton(
+                          onPressed: () => Navigator.of(sheetContext).pop(),
+                          child: const Text('Cancel'),
+                        ),
+                        const Spacer(),
+                        FilledButton(
+                          onPressed: () async {
+                            if (sheetFormKey.currentState!.validate()) {
+                              final lastPage = int.parse(_pageController.text);
+                              final notifier = ref.read(
+                                sessionRecordingNotifierProvider.notifier,
+                              );
+                              final success = await notifier.saveSession(
+                                lastPage,
+                                userPageCount: pagesAdjusted
+                                    ? adjustedTotal
+                                    : null,
+                              );
+                              if (!sheetContext.mounted) return;
+                              if (success) {
+                                ref.invalidate(bookmarkNotifierProvider);
+                                ref.invalidate(libraryNotifierProvider);
+                                Navigator.of(sheetContext).pop();
+                                if (context.mounted) {
+                                  context.pop();
+                                }
+                              } else {
+                                ScaffoldMessenger.of(context).showSnackBar(
+                                  SnackBar(
+                                    content: Text(
+                                      notifier.errorMessage ??
+                                          'Failed to save session',
+                                    ),
+                                    backgroundColor: Theme.of(
+                                      context,
+                                    ).colorScheme.error,
+                                  ),
+                                );
+                              }
+                            }
+                          },
+                          child: const Text('Save Session'),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+            );
+          },
         );
       },
-    );
+    ).whenComplete(() {
+      totalPagesController.dispose();
+    });
   }
 
   @override
@@ -330,11 +536,16 @@ class _SessionRecordingPageState extends ConsumerState<SessionRecordingPage> {
                   child: FilledButton.icon(
                     onPressed: () {
                       sessionNotifier.pauseTimer();
+                      final effectiveTotal = readingProgress.effectivePageCount;
+                      if (_pageController.text.isEmpty) {
+                        _pageController.text = readingProgress.currentPage
+                            .toString();
+                      }
                       setState(() {});
-                      _showSaveSessionDialog(
+                      _showSaveBottomSheet(
                         context,
                         readingProgress.currentPage,
-                        book.pageCount,
+                        effectiveTotal,
                       );
                     },
                     icon: const Icon(Icons.check),

--- a/lib/features/reading_tracker/viewmodel/reading_tracker_viewmodel.dart
+++ b/lib/features/reading_tracker/viewmodel/reading_tracker_viewmodel.dart
@@ -40,6 +40,7 @@ class ReadingTrackerNotifier extends _$ReadingTrackerNotifier {
   Future<void> updateReadingProgress(
     int newCurrentPage, {
     int? durationInSeconds,
+    int? userPageCount,
   }) async {
     try {
       final currentState = state.value;
@@ -52,6 +53,7 @@ class ReadingTrackerNotifier extends _$ReadingTrackerNotifier {
         currentPage: newCurrentPage,
         totalReadingTimeInSeconds: updatedTotalReadingTime,
         lastRead: DateTime.now(),
+        userPageCount: userPageCount,
       );
 
       await _sqfliteService.saveReadingProgress(updatedProgress);

--- a/lib/features/reading_tracker/viewmodel/session_recording_viewmodel.dart
+++ b/lib/features/reading_tracker/viewmodel/session_recording_viewmodel.dart
@@ -87,7 +87,7 @@ class SessionRecordingNotifier extends _$SessionRecordingNotifier {
     _stopWatchTimer.onResetTimer();
   }
 
-  Future<bool> saveSession(int endPage) async {
+  Future<bool> saveSession(int endPage, {int? userPageCount}) async {
     if (_hasError || !_isInitialized || _initialProgress == null) {
       return false;
     }
@@ -100,6 +100,7 @@ class SessionRecordingNotifier extends _$SessionRecordingNotifier {
           .updateReadingProgress(
             endPage,
             durationInSeconds: totalElapsedSeconds,
+            userPageCount: userPageCount,
           );
 
       final session = ReadingSessionModel(


### PR DESCRIPTION
- migrate database to v3 with userPageCount column
- replace save session dialog with interactive bottom sheet
- allow users to override default edition length
- update progress models and viewmodels to handle adjusted totals