### PR TITLE
Fix/notification display

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -38,6 +38,8 @@
             android:value="2" />
     </application>
     <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM"/>
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
     <!-- Required to query activities that can process text, see:
          https://developer.android.com/training/package-visibility and
          https://developer.android.com/reference/android/content/Intent#ACTION_PROCESS_TEXT.

--- a/lib/features/notifications/service/notification_service.dart
+++ b/lib/features/notifications/service/notification_service.dart
@@ -12,7 +12,7 @@ class NotificationService {
 
   Future<SharedPreferences> get _prefs => SharedPreferences.getInstance();
 
-  Future<void> initialize() async {
+  Future<void> initialize({bool requestPermissions = true}) async {
     const androidSettings = AndroidInitializationSettings(
       '@mipmap/ic_launcher',
     );
@@ -23,9 +23,14 @@ class NotificationService {
       requestSoundPermission: true,
     );
 
+    const linuxSettings = LinuxInitializationSettings(
+      defaultActionName: 'Open',
+    );
+
     const initSettings = InitializationSettings(
       android: androidSettings,
       iOS: iosSettings,
+      linux: linuxSettings,
     );
 
     await _plugin.initialize(
@@ -33,11 +38,13 @@ class NotificationService {
       onDidReceiveNotificationResponse: _onNotificationTap,
     );
 
-    await _plugin
-        .resolvePlatformSpecificImplementation<
-          AndroidFlutterLocalNotificationsPlugin
-        >()
-        ?.requestNotificationsPermission();
+    if (requestPermissions) {
+      final androidPlugin = _plugin.resolvePlatformSpecificImplementation<
+        AndroidFlutterLocalNotificationsPlugin>();
+
+      await androidPlugin?.requestNotificationsPermission();
+      await androidPlugin?.requestExactAlarmsPermission();
+    }
   }
 
   void _onNotificationTap(NotificationResponse response) {
@@ -74,6 +81,38 @@ class NotificationService {
   Future<void> setLastNotificationDate(DateTime date) async {
     final prefs = await _prefs;
     await prefs.setString(_lastNotificationDateKey, date.toIso8601String());
+  }
+
+  Future<void> show({
+    required String title,
+    required String body,
+    String? payload,
+  }) async {
+    const androidDetails = AndroidNotificationDetails(
+      'reading_reminder',
+      'Reading Reminder',
+      channelDescription: 'Daily reading reminders and streak alerts',
+      importance: Importance.high,
+      priority: Priority.high,
+    );
+
+    const linuxDetails = LinuxNotificationDetails(
+      urgency: LinuxNotificationUrgency.critical,
+    );
+
+    const details = NotificationDetails(
+      android: androidDetails,
+      linux: linuxDetails,
+    );
+
+    final id = DateTime.now().millisecondsSinceEpoch.remainder(100000).abs();
+    await _plugin.show(
+      id: id,
+      title: title,
+      body: body,
+      notificationDetails: details,
+      payload: payload,
+    );
   }
 
   Future<void> schedule(ReminderDecision decision, DateTime at) async {

--- a/lib/features/notifications/service/notification_service.dart
+++ b/lib/features/notifications/service/notification_service.dart
@@ -50,20 +50,22 @@ class NotificationService {
   void _onNotificationTap(NotificationResponse response) {
     final action = response.actionId;
     if (action == null) {
-      _onTapCallback?.call(response.payload);
+      _onTapCallback?.call(response.payload, response.id);
       return;
     }
     if (action == 'session_pause_resume' || action == 'session_finish') {
       _onSessionActionCallback?.call(action, response.payload);
     } else {
-      _onTapCallback?.call(response.payload);
+      _onTapCallback?.call(response.payload, response.id);
     }
   }
 
-  Function(String?)? _onTapCallback;
+  Function(String? payload, int? notificationId)? _onTapCallback;
   Function(String actionId, String? payload)? _onSessionActionCallback;
 
-  set onNotificationTap(Function(String?)? callback) {
+  set onNotificationTap(
+    Function(String? payload, int? notificationId)? callback,
+  ) {
     _onTapCallback = callback;
   }
 
@@ -154,7 +156,7 @@ class NotificationService {
     }
   }
 
-  static const int _sessionOngoingId = 9999;
+  static const int sessionOngoingId = 9999;
   static const String _sessionChannelId = 'session_ongoing';
   static const String _sessionChannelName = 'Session Timer';
   static const String _sessionChannelDesc =
@@ -217,7 +219,7 @@ class NotificationService {
       );
 
       await _plugin.show(
-        id: _sessionOngoingId,
+        id: sessionOngoingId,
         title: bookTitle,
         body: '$timeStr • $progress • $statusBadge',
         notificationDetails: details,
@@ -228,7 +230,7 @@ class NotificationService {
 
   Future<void> cancelSessionOngoing() async {
     try {
-      await _plugin.cancel(id: _sessionOngoingId);
+      await _plugin.cancel(id: sessionOngoingId);
     } catch (_) {}
   }
 

--- a/lib/features/reading_tracker/viewmodel/session_recording_viewmodel.dart
+++ b/lib/features/reading_tracker/viewmodel/session_recording_viewmodel.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:book_verse/core/router/app_router.dart';
 import 'package:book_verse/features/bookmarks/viewmodel/bookmark_viewmodel.dart';
 import 'package:book_verse/features/library/viewmodel/library_viewmodel.dart';
 import 'package:book_verse/features/notifications/providers/notification_providers.dart';
@@ -100,6 +101,10 @@ class SessionRecordingNotifier extends _$SessionRecordingNotifier {
         }
       } else if (actionId == 'session_finish') {
         pauseTimer();
+        final router = ref.read(routerProvider);
+        if (payload != null) {
+          router.push('/record-session/$payload');
+        }
       }
     };
   }

--- a/lib/features/settings/view/pages/reminder_settings_page.dart
+++ b/lib/features/settings/view/pages/reminder_settings_page.dart
@@ -1,5 +1,4 @@
 import 'package:book_verse/core/theme/themes_extension.dart';
-import 'package:book_verse/features/notifications/model/reminder_type.dart';
 import 'package:book_verse/features/notifications/service/notification_service.dart';
 import 'package:book_verse/features/settings/model/reminder_settings.dart';
 import 'package:flutter/material.dart';
@@ -84,25 +83,33 @@ class _ReminderSettingsPageState extends State<ReminderSettingsPage> {
   }
 
   Future<void> _testNotification() async {
-    final service = NotificationService(
-      FlutterLocalNotificationsPlugin(),
-    );
-    await service.initialize();
-    await service.schedule(
-      ReminderDecision(
-        type: ReminderType.resumeBook,
+    try {
+      final service = NotificationService(
+        FlutterLocalNotificationsPlugin(),
+      );
+      await service.initialize(requestPermissions: true);
+      await service.show(
         title: 'Test Notification',
         body: 'Reading reminders are working!',
-      ),
-      DateTime.now().add(const Duration(seconds: 3)),
-    );
-    if (mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-          content: Text('Test notification sent (check in 3 seconds)'),
-          behavior: SnackBarBehavior.floating,
-        ),
       );
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Test notification sent!'),
+            behavior: SnackBarBehavior.floating,
+          ),
+        );
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Failed to send notification: $e'),
+            behavior: SnackBarBehavior.floating,
+            backgroundColor: Theme.of(context).colorScheme.error,
+          ),
+        );
+      }
     }
   }
 

--- a/lib/features/settings/view/sections/reminder_section.dart
+++ b/lib/features/settings/view/sections/reminder_section.dart
@@ -1,5 +1,4 @@
 import 'package:book_verse/core/theme/themes_extension.dart';
-import 'package:book_verse/features/notifications/model/reminder_type.dart';
 import 'package:book_verse/features/notifications/service/notification_service.dart';
 import 'package:book_verse/features/settings/model/reminder_settings.dart';
 import 'package:flutter/material.dart';
@@ -84,25 +83,33 @@ class _ReminderSectionState extends State<ReminderSection> {
   }
 
   Future<void> _testNotification() async {
-    final service = NotificationService(
-      FlutterLocalNotificationsPlugin(),
-    );
-    await service.initialize();
-    await service.schedule(
-      ReminderDecision(
-        type: ReminderType.resumeBook,
+    try {
+      final service = NotificationService(
+        FlutterLocalNotificationsPlugin(),
+      );
+      await service.initialize(requestPermissions: true);
+      await service.show(
         title: 'Test Notification',
         body: 'Reading reminders are working!',
-      ),
-      DateTime.now().add(const Duration(seconds: 3)),
-    );
-    if (mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-          content: Text('Test notification sent (check in 3 seconds)'),
-          behavior: SnackBarBehavior.floating,
-        ),
       );
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Test notification sent!'),
+            behavior: SnackBarBehavior.floating,
+          ),
+        );
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Failed to send notification: $e'),
+            behavior: SnackBarBehavior.floating,
+            backgroundColor: Theme.of(context).colorScheme.error,
+          ),
+        );
+      }
     }
   }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:book_verse/core/services/supabase_service.dart';
 import 'package:book_verse/core/theme/providers/thememode_provider.dart';
 import 'package:book_verse/core/theme/app_theme.dart';
 import 'package:book_verse/features/notifications/providers/notification_providers.dart';
+import 'package:book_verse/features/notifications/service/notification_service.dart';
 import 'package:device_preview/device_preview.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -72,6 +73,24 @@ class _MyAppState extends ConsumerState<MyApp> {
     try {
       final service = ref.read(notificationServiceProvider);
       await service.initialize();
+      service.onNotificationTap = (payload, notificationId) {
+        final router = ref.read(routerProvider);
+
+        if (notificationId == NotificationService.sessionOngoingId) {
+          if (payload != null) {
+            router.push('/record-session/$payload');
+          } else {
+            router.push('/dashboard');
+          }
+          return;
+        }
+
+        if (payload != null) {
+          router.push('/tracked-book-detail/$payload');
+        } else {
+          router.push('/dashboard');
+        }
+      };
       await scheduleDailyReminder(ref);
     } catch (e, stack) {
       log('Failed to initialize notifications: $e\n$stack');

--- a/test/features/notifications/service/notification_service_test.dart
+++ b/test/features/notifications/service/notification_service_test.dart
@@ -41,7 +41,7 @@ void main() {
   group('onNotificationTap', () {
     test('setter accepts a callback', () {
       expect(() {
-        service.onNotificationTap = (payload) {};
+        service.onNotificationTap = (payload, notificationId) {};
       }, returnsNormally);
     });
   });


### PR DESCRIPTION
Fixes test notification crash on Android 12+ (missing SCHEDULE_EXACT_ALARM permission) and Linux (zonedSchedule throws UnimplementedError). Connects notification tap to correct in-app page based on notification type.
Changes

1. Tap "Send Test Notification" in Settings → Reminders → confirm it shows on Android/Linux without crash
2. Start a reading session, lock screen, tap the ongoing notification → navigates to /record-session/$bookId
3. Schedule a daily reminder with a tracked book → tap notification → navigates to /tracked-book-detail/$bookId
4. Schedule a daily reminder without a tracked book → tap notification → navigates to /dashboard
5. Swipe away session notification, tap "Finish" action → navigates to session page