### PR TITLE
fix(android): fix release build errors and harden Android config

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -56,6 +56,12 @@ android {
 
     buildTypes {
         release {
+            isMinifyEnabled = true
+            isShrinkResources = true
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
             signingConfig = if (keystorePropertiesFile.exists()) {
                 signingConfigs.getByName("release")
             } else {
@@ -68,7 +74,7 @@ android {
 dependencies {
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.4")
 
-    implementation("com.google.android.material:material:1.14.0-alpha01")
+    implementation("com.google.android.material:material:1.14.0")
 
     implementation(platform("com.google.firebase:firebase-bom:34.14.0"))
     implementation("com.google.firebase:firebase-analytics")

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -31,15 +31,6 @@
                 <data android:scheme="bookverse" android:host="callback"/>
             </intent-filter>
         </activity>
-        <receiver android:name="com.dexterous.flutterlocalnotifications.ScheduledNotificationReceiver" />
-        <receiver android:name="com.dexterous.flutterlocalnotifications.ScheduledNotificationBootReceiver">
-            <intent-filter>
-                <action android:name="android.intent.action.BOOT_COMPLETED"/>
-                <action android:name="android.intent.action.MY_PACKAGE_REPLACED"/>
-                <action android:name="android.intent.action.QUICKBOOT_POWERON"/>
-                <action android:name="com.htc.intent.action.QUICKBOOT_POWERON"/>
-            </intent-filter>
-        </receiver>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
         <meta-data

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -5,16 +5,6 @@ allprojects {
     }
 }
 
-buildscript {
-    repositories {
-        google()
-        mavenCentral()
-    }
-    dependencies {
-        classpath("com.google.gms:google-services:4.4.2")
-    }
-}
-
 plugins {
   // ...
 

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,6 +1,6 @@
-org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
+org.gradle.jvmargs=-Xmx4G -XX:MaxMetaspaceSize=2G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
-android.enableJetifier=true
+android.enableJetifier=false
 # This builtInKotlin flag was added automatically by Flutter migrator
 android.builtInKotlin=false
 # This newDsl flag was added automatically by Flutter migrator

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,8 +11,8 @@ dependencies:
   flutter_chat_ui: ^2.0.0
   flutter:
     sdk: flutter
-  flutter_local_notifications:
-  flutter_timezone:
+  flutter_local_notifications: ^22.0.1
+  flutter_timezone: ^5.1.0
   timezone:
   flutter_dotenv: ^5.2.1
   flutter_riverpod: ^2.6.1


### PR DESCRIPTION
- Remove manual receiver declarations in AndroidManifest.xml that caused android:exported error on Android 12+
- Remove conflicting google-services classpath in build.gradle.kts
- Enable R8 minification and resource shrinking for release builds
- Update Material library from alpha to stable 1.14.0
- Disable Jetifier (all deps are AndroidX native)
- Reduce JVM heap from 8G to 4G for CI compatibility
- Pin flutter_local_notifications and flutter_timezone versions